### PR TITLE
(Fix) Guard against null children types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/react-passage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Link and Redirect to routes safely in your react applications",
   "author": "Jacob Kelley <jacob.kelley@dollarshaveclub.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,10 @@ const { Provider, Consumer } = createContext()
 // Flattens children into a list and filters by Route
 const getRoutes = (children, targets, matches = []) => {
   Children.forEach(children, (child) => {
-    matches.push(child)
-    if (child.props.children) return getRoutes(child.props.children, targets, matches)
+    if (child) {
+      matches.push(child)
+      if (child.props.children) return getRoutes(child.props.children, targets, matches)
+    }
   })
   return matches.filter(child => {
     for (const index in targets) {
@@ -52,9 +54,11 @@ export const Passage =
 Passage.propTypes = {
   targets: PropTypes.array.isRequired,
   children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.arrayOf(
+      PropTypes.node
+    ),
     PropTypes.node,
-  ]).isRequired,
+  ]),
 }
 Passage.defaultProps = {
   targets: [Route],

--- a/src/test.js
+++ b/src/test.js
@@ -100,6 +100,21 @@ describe('react-passage', () => {
     )
     expect(mockVia).toHaveBeenCalledWith('/our-products')
   })
+
+  describe('Children types', () => {
+    it('can handle null children types', () => {
+      renderer.create(
+        <Passage>
+          {null}
+          <MemoryRouter>
+            <Switch>
+              <Route path='/get-started' exact render={() => <p>Redirected!</p>} />
+            </Switch>
+          </MemoryRouter>
+        </Passage>
+      )
+    })
+  })
 })
 
 /**


### PR DESCRIPTION
## Fixes

Fixes against `null` children types.  `Null` as child should be supported.


> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
