### PR TITLE
feat(): support the overriding of passage for native implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const changeRedirectExample = () => (
 ```
 
 ### Override Passage Matching
-Sometimes you do not want to have Passage take effect for certain links. To override the react-router implementations, simply pass `native` as an attribute to the `Link` or `Redirect` component to have it force the native browser implementation (Anchor Tags or `location.assign`, for example).
+Sometimes you do not want to have Passage take effect for certain links. To override the react-router implementations, pass `native` as an attribute to the `Link` or `Redirect` component to have it force the native browser implementation (Anchor Tags or `location.assign`, for example).
 
 ```js
 import React from 'react'

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ _Note: There may be some issues with nested react routes. [Read more here](https
 Install via NPM:
 
 ```sh
-
 npm i @dollarshaveclub/react-passage@latest --save
-
 ```
 
 ## Usage
@@ -32,7 +30,6 @@ Passage provides three exports.
 ### Wrap the `Passage` component around your routes
 
 ```js
-
 import React from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 
@@ -49,13 +46,11 @@ const App = () => (
     </BrowserRouter>
   </Passage>
 )
-
 ```
 
 The Passage component accepts an optional prop called `targets`. This is an array of components that you want to search for within your routes file. It has a value of `[Route]` by default.
 
 ```js
-
 const App = () => (
   <Passage targets={[ Route, MyCustomRoute ]}>
     <BrowserRouter>
@@ -67,13 +62,11 @@ const App = () => (
     </BrowserRouter>
   </Passage>
 )
-
 ```
 
 ### Leverage Passage Links and Redirects
 
 ```js
-
 import React from 'react'
 
 import {
@@ -91,7 +84,21 @@ const externalExample = () => (<Redirect to='/external-path' />)
 const changeRedirectExample = () => (
   <Redirect to='/new-website' via={(to) => window.location.href = to} />
 )
+```
 
+### Override Passage Matching
+Sometimes you do not want to have Passage take effect for certain links. To override the react-router implementations, simply pass `native` as an attribute to the `Link` or `Redirect` component to have it force the native browser implementation (Anchor Tags or `location.assign`, for example).
+
+```js
+import React from 'react'
+
+import {
+  Link,
+  Redirect,
+} from '@dollarshaveclub/react-passage'
+
+const plainAnchorTag = <Link to='/about' native>About</Link>
+const plainRedirect = <Redirect via={window.location.assign} to='/About' native>About</Redirect>
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ const changeRedirectExample = () => (
 ```
 
 ### Override Passage Matching
+
 Sometimes you do not want to have Passage take effect for certain links. To override the react-router implementations, pass `native` as an attribute to the `Link` or `Redirect` component to have it force the native browser implementation (Anchor Tags or `location.assign`, for example).
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/react-passage",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Link and Redirect to routes safely in your react applications",
   "author": "Jacob Kelley <jacob.kelley@dollarshaveclub.com>",
   "license": "MIT",

--- a/src/__snapshots__/test.js.snap
+++ b/src/__snapshots__/test.js.snap
@@ -8,7 +8,7 @@ exports[`react-passage redirects to a matched react route 1`] = `
 
 exports[`react-passage when a route is matched matches the snapshot 1`] = `
 <a
-  data-safelink-type="link"
+  data-passage-link-type="pushState"
   href="/get-started/plan/shave"
   onClick={[Function]}
 >
@@ -16,10 +16,20 @@ exports[`react-passage when a route is matched matches the snapshot 1`] = `
 </a>
 `;
 
+exports[`react-passage when a route is matched supports native overrides 1`] = `
+<a
+  data-passage-link-type="anchor"
+  href="/get-started/plan/shave"
+>
+  Shave Core
+</a>
+`;
+
 exports[`react-passage when a route is unmatched matches the snapshot 1`] = `
 <a
-  data-safelink-type="a"
+  data-passage-link-type="pushState"
   href="/blades"
+  onClick={[Function]}
 >
   Blades
 </a>
@@ -27,7 +37,7 @@ exports[`react-passage when a route is unmatched matches the snapshot 1`] = `
 
 exports[`react-passage when there is no context matches the snapshot 1`] = `
 <a
-  data-safelink-type="a"
+  data-passage-link-type="anchor"
   href="/blades"
 >
   Blades

--- a/src/test.js
+++ b/src/test.js
@@ -61,6 +61,23 @@ describe('react-passage', () => {
       expectComponentToRenderSafeLink(component, ReactRouterLink, href)
     })
 
+    it('supports native overrides', () => {
+      const nativeComponent = renderer.create(
+        <Passage>
+          <MemoryRouter>
+            <Switch>
+              <Route path='/get-started/plan/:planId' exact render={() => {}} />
+
+              <Route render={() => (
+                <Link to={href} native>Shave Core</Link>
+              )} />
+            </Switch>
+          </MemoryRouter>
+        </Passage>
+      )
+      expect(nativeComponent.toJSON()).toMatchSnapshot()
+    })
+
     it('matches the snapshot', () => {
       expect(component.toJSON()).toMatchSnapshot()
     })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,18 +1,22 @@
 import { LocationDescriptor } from 'history'
-import * as React from 'react'
-import { LinkProps, RedirectProps as ReactRouterRedirectProps, Route } from 'react-router-dom'
+import { FunctionComponent, ReactNode } from 'react'
+import { LinkProps as ReactRouterLinkProps, RedirectProps as ReactRouterRedirectProps, Route } from 'react-router-dom'
 
-export const Link: React.FunctionComponent<LinkProps>
+type NativeOverride = {
+  native?: boolean
+}
 
-interface RedirectProps extends ReactRouterRedirectProps, Readonly<{
+type RedirectProps = ReactRouterRedirectProps & NativeOverride & {
   via?: (to: LocationDescriptor) => void
-}> {}
+}
 
-export const Redirect: React.FunctionComponent<RedirectProps>
+type LinkProps = ReactRouterLinkProps & NativeOverride
 
 interface PassageProps extends Readonly<{
-  children: React.ReactNode
+  children: ReactNode
   targets?: Array<typeof Route>
 }> {}
 
-export const Passage: React.FunctionComponent<PassageProps>
+export const Redirect: FunctionComponent<RedirectProps>
+export const Link: FunctionComponent<LinkProps>
+export const Passage: FunctionComponent<PassageProps>


### PR DESCRIPTION
### Override Passage Matching
Sometimes you do not want to have Passage take effect for certain links. To override the react-router implementations, simply pass `native` as an attribute to the `Link` or `Redirect` component to have it force the native browser implementation (Anchor Tags or `location.assign`, for example).

```js
import React from 'react'

import {
  Link,
  Redirect,
} from '@dollarshaveclub/react-passage'

const plainAnchorTag = <Link to='/about' native>About</Link>
const plainRedirect = <Redirect via={window.location.assign} to='/About' native>About</Redirect>
```