### PR TITLE
feat(): allow location object in to prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/react-passage",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Link and Redirect to routes safely in your react applications",
   "author": "Jacob Kelley <jacob.kelley@dollarshaveclub.com>",
   "license": "MIT",

--- a/src/__snapshots__/test.js.snap
+++ b/src/__snapshots__/test.js.snap
@@ -16,6 +16,16 @@ exports[`react-passage when a route is matched matches the snapshot 1`] = `
 </a>
 `;
 
+exports[`react-passage when a route is matched matches with a location object 1`] = `
+<a
+  data-safelink-type="link"
+  href="/get-started/plan/shave"
+  onClick={[Function]}
+>
+  Shave Core
+</a>
+`;
+
 exports[`react-passage when a route is unmatched matches the snapshot 1`] = `
 <a
   data-safelink-type="a"

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,9 @@ export const Link = forwardRef(
 Link.propTypes = {
   to: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.object,
+    PropTypes.shape({
+      pathname: PropTypes.string,
+    }),
   ]).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ const MatchFactory = (routes) => (to) => {
       },
     } = route
 
-    const pathname = typeof to === 'object' ? to.pathname : to
+    const pathname = typeof to === 'string' ? to : ('pathname' in to ? to.pathname : null)
+    if (!pathname) return false
 
     return matchPath(pathname, {
       path,

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,10 @@ const MatchFactory = (routes) => (to) => {
         strict,
       },
     } = route
-    return matchPath(to, {
+
+    const pathname = typeof to === 'object' ? to.pathname : to
+
+    return matchPath(pathname, {
       path,
       exact,
       strict,
@@ -76,7 +79,10 @@ export const Link = forwardRef(
 )
 
 Link.propTypes = {
-  to: PropTypes.string.isRequired,
+  to: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,

--- a/src/test.js
+++ b/src/test.js
@@ -42,27 +42,31 @@ describe('react-passage', () => {
   describe('when a route is matched', () => {
     const href = '/get-started/plan/shave'
 
-    const component = renderer.create(
+    const component = (link) => renderer.create(
       <Passage>
         <MemoryRouter>
           <Switch>
             <Route path='/get-started/plan/:planId' exact render={() => {}} />
             <Route path='/users/:id' exact render={() => {}} />
 
-            <Route render={() => (
-              <Link to={href}>Shave Core</Link>
-            )} />
+            <Route render={() => (link)} />
           </Switch>
         </MemoryRouter>
       </Passage>
     )
 
     it('renders a Link tag', () => {
-      expectComponentToRenderSafeLink(component, ReactRouterLink, href)
+      expectComponentToRenderSafeLink(component(<Link to={href}>Shave Core</Link>), ReactRouterLink, href)
     })
 
     it('matches the snapshot', () => {
-      expect(component.toJSON()).toMatchSnapshot()
+      expect(component(<Link to={href}>Shave Core</Link>).toJSON()).toMatchSnapshot()
+    })
+
+    it('matches with a location object', () => {
+      expect(component(<Link to={{
+        pathname: href,
+      }}>Shave Core</Link>).toJSON()).toMatchSnapshot()
     })
   })
 


### PR DESCRIPTION
## Fixes

```jsx
import { Link } from '@dollarshaveclub/react-passage'

const link = (
  <Link to={{
    pathname: '/account'
  }}>Account</Link>
)
```

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
