### PR TITLE
feat(passage): support link type to anchor override

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ import {
 // Renders a React Router Link tag if it can, otherwise falls back to an anchor tag
 const aboutExample = () => (<Link to='/about'>About</Link>)
 
+// Force Link to render an anchor tag
+const externalExample = () => (<Link external to='https://www.google.com'>Google</Link>)
+
 // Redirects with react-history if route exists, otherwise, uses window.location.assign
 const externalExample = () => (<Redirect to='/external-path' />)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/react-passage",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Link and Redirect to routes safely in your react applications",
   "author": "Jacob Kelley <jacob.kelley@dollarshaveclub.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -83,37 +83,39 @@ export const toStringFromLocationObject = (to, location) => {
 }
 
 // Consumes the matcher function and checks the URL against the defined routes
-export const Link = forwardRef(({ to, children, ...remainingProps }, ref) => {
-  const location = useLocation()
+export const Link = forwardRef(
+  ({ to, external, children, ...remainingProps }, ref) => {
+    const location = useLocation()
 
-  return (
-    <Consumer>
-      {(doesMatch) => {
-        if (!doesMatch || !doesMatch(to))
+    return (
+      <Consumer>
+        {(doesMatch) => {
+          if (!doesMatch || external || !doesMatch(to))
+            return (
+              <a
+                data-safelink-type="a"
+                href={toStringFromLocationObject(to, location)}
+                {...remainingProps}
+                ref={ref}
+              >
+                {children}
+              </a>
+            )
           return (
-            <a
-              data-safelink-type="a"
-              href={toStringFromLocationObject(to, location)}
+            <ReactRouterLink
+              data-safelink-type="link"
+              to={to}
               {...remainingProps}
               ref={ref}
             >
               {children}
-            </a>
+            </ReactRouterLink>
           )
-        return (
-          <ReactRouterLink
-            data-safelink-type="link"
-            to={to}
-            {...remainingProps}
-            ref={ref}
-          >
-            {children}
-          </ReactRouterLink>
-        )
-      }}
-    </Consumer>
-  )
-})
+        }}
+      </Consumer>
+    )
+  }
+)
 
 Link.displayName = 'PassageLink'
 
@@ -125,6 +127,7 @@ Link.propTypes = {
     PropTypes.string,
     PropTypes.func,
   ]).isRequired,
+  external: PropTypes.bool,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,

--- a/src/test.js
+++ b/src/test.js
@@ -119,6 +119,18 @@ describe('react-passage', () => {
       ).toMatchSnapshot()
       expect(useLocation).toHaveBeenCalled()
     })
+
+    it('matches but is overridden with external flag', () => {
+      expectComponentToRenderSafeLink(
+        component(
+          <Link external to={href}>
+            Shave Core
+          </Link>
+        ),
+        'a',
+        href
+      )
+    })
   })
 
   it('redirects to a route without context', () => {


### PR DESCRIPTION
## Feature

Supports a manual override for links with protocols. `react-router-dom/Link` has trouble rendering external URLs with protocols.

```jsx
<Link external to='https://google.com'>Google</Link>
```