### PR TITLE
fix: ensure urls with different origins are not rendered as local react-router-dom Links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/react-passage",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Link and Redirect to routes safely in your react applications",
   "author": "Jacob Kelley <jacob.kelley@dollarshaveclub.com>",
   "license": "MIT",

--- a/src/__snapshots__/test.js.snap
+++ b/src/__snapshots__/test.js.snap
@@ -48,7 +48,7 @@ exports[`react-passage when a route is unmatched matches the snapshot 1`] = `
   data-safelink-type="a"
   href="/blades"
 >
-  Blades
+  Dummy Link
 </a>
 `;
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {
 } from 'react-router-dom'
 import { matchPath, useLocation } from 'react-router'
 import PropTypes from 'prop-types'
+import { isSameOriginAsCurrentPage, removeOriginFromUrl } from './urlUtilities'
 
 // Create our Context API
 const { Provider, Consumer } = createContext()
@@ -40,7 +41,11 @@ const MatchFactory = (routes) => (to) => {
     } = route
 
     const url = toStringFromLocationObject(to)
+
     if (!url) return false
+
+    if (!isSameOriginAsCurrentPage(url)) return false
+
     a.href = url
     const toPath = a.pathname
 
@@ -101,10 +106,13 @@ export const Link = forwardRef(
                 {children}
               </a>
             )
+
+          const pathname = removeOriginFromUrl(toStringFromLocationObject(to))
+
           return (
             <ReactRouterLink
               data-safelink-type="link"
-              to={to}
+              to={pathname}
               {...remainingProps}
               ref={ref}
             >

--- a/src/test.js
+++ b/src/test.js
@@ -90,7 +90,7 @@ describe('react-passage', () => {
       window.location = realLocation
     })
 
-    const component = (link) =>
+    const renderDummyRoutes = (link) =>
       renderer.create(
         <Passage>
           <MemoryRouter>
@@ -107,7 +107,7 @@ describe('react-passage', () => {
 
     it('renders a Link tag, when relative path matches', () => {
       expectComponentToRenderSafeLink(
-        component(<Link to={hrefRelativeMatch}>Shave Core</Link>),
+        renderDummyRoutes(<Link to={hrefRelativeMatch}>Shave Core</Link>),
         ReactRouterLink,
         hrefRelativeMatch
       )
@@ -115,7 +115,7 @@ describe('react-passage', () => {
 
     it('renders a Link tag, when fully qualified url matches', () => {
       expectComponentToRenderSafeLink(
-        component(<Link to={hrefFullyQualifiedMatch}>Shave Core</Link>),
+        renderDummyRoutes(<Link to={hrefFullyQualifiedMatch}>Shave Core</Link>),
         ReactRouterLink,
         hrefRelativeMatch
       )
@@ -125,7 +125,7 @@ describe('react-passage', () => {
       const hrefWithQueryParams = '/get-started?source=foo&medium=nav'
       const LinkComponent = <Link to={hrefWithQueryParams}>Shave Core</Link>
       expectComponentToRenderSafeLink(
-        component(LinkComponent),
+        renderDummyRoutes(LinkComponent),
         ReactRouterLink,
         hrefWithQueryParams
       )
@@ -134,13 +134,15 @@ describe('react-passage', () => {
 
     it('matches the snapshot', () => {
       expect(
-        component(<Link to={hrefRelativeMatch}>Shave Core</Link>).toJSON()
+        renderDummyRoutes(
+          <Link to={hrefRelativeMatch}>Shave Core</Link>
+        ).toJSON()
       ).toMatchSnapshot()
     })
 
     it('matches with a location object', () => {
       expect(
-        component(
+        renderDummyRoutes(
           <Link
             to={{
               pathname: hrefRelativeMatch,
@@ -154,14 +156,16 @@ describe('react-passage', () => {
 
     it('matches with a function that returns a location object', () => {
       expect(
-        component(<Link to={(location) => location}>Shave Core</Link>).toJSON()
+        renderDummyRoutes(
+          <Link to={(location) => location}>Shave Core</Link>
+        ).toJSON()
       ).toMatchSnapshot()
       expect(useLocation).toHaveBeenCalled()
     })
 
     it('matches but is overridden with external flag', () => {
       expectComponentToRenderSafeLink(
-        component(
+        renderDummyRoutes(
           <Link external to={hrefRelativeMatch}>
             Shave Core
           </Link>

--- a/src/urlUtilities.js
+++ b/src/urlUtilities.js
@@ -15,3 +15,18 @@ export const isSameOriginAsCurrentPage = (url) => {
 
   return inputOrigin === currentOrigin
 }
+
+/**
+ * Remove origin, to keep the "absolute path", including: pathname, search and hash
+ * Returns Example: /get-started?q=monday#description
+ */
+export const removeOriginFromUrl = (url) => {
+  if (typeof url !== 'string') {
+    throw new TypeError('removeOriginFromUrl(): url must be string')
+  }
+
+  const objUrl = parseUrl(url)
+  const result = objUrl.href.replace(objUrl.origin, '')
+
+  return result
+}

--- a/src/urlUtilities.js
+++ b/src/urlUtilities.js
@@ -1,0 +1,6 @@
+export function parseUrl(url) {
+  const DEFAULT_BASE = window.location.origin || 'http://localhost'
+  const urlObj = new URL(url, DEFAULT_BASE)
+
+  return urlObj
+}

--- a/src/urlUtilities.js
+++ b/src/urlUtilities.js
@@ -4,3 +4,14 @@ export function parseUrl(url) {
 
   return urlObj
 }
+
+export const isSameOriginAsCurrentPage = (url) => {
+  if (!window || !window.location) {
+    return false
+  }
+
+  const inputOrigin = parseUrl(url).origin
+  const currentOrigin = window.location.origin
+
+  return inputOrigin === currentOrigin
+}

--- a/src/urlUtilities.test.js
+++ b/src/urlUtilities.test.js
@@ -1,4 +1,4 @@
-import { parseUrl } from './urlUtilities'
+import { parseUrl, isSameOriginAsCurrentPage } from './urlUtilities'
 
 describe('parseUrl()', () => {
   describe('parsing relative urls', () => {
@@ -27,5 +27,58 @@ describe('parseUrl()', () => {
       const result = parseUrl(FULL_URL)
       expect(result.origin).toBe('http://www.shave.com')
     })
+  })
+})
+
+describe('isSameOriginAsCurrentPage()', () => {
+  const MOCK_LOCATION = {
+    hash: '',
+    host: 'uk.dollarshaveclub.com',
+    hostname: 'uk.dollarshaveclub.com',
+    href: 'https://uk.dollarshaveclub.com/',
+    origin: 'https://uk.dollarshaveclub.com',
+    pathname: '/',
+    port: '',
+    protocol: 'https:',
+  }
+
+  let realLocation
+
+  beforeAll(() => {
+    realLocation = window.location
+    delete window.location
+    window.location = MOCK_LOCATION
+  })
+
+  afterAll(() => {
+    window.location = realLocation
+  })
+
+  it('META: mocks correctly', () => {
+    expect(window.location.host).toEqual('uk.dollarshaveclub.com')
+  })
+
+  it('retuns true, when origins match', () => {
+    const result = isSameOriginAsCurrentPage(
+      'https://uk.dollarshaveclub.com/get-started'
+    )
+    expect(result).toBe(true)
+  })
+
+  it('returns false, when origins do not match (V1)', () => {
+    const result = isSameOriginAsCurrentPage(
+      'https://ca.dollarshaveclub.com/get-started'
+    )
+    expect(result).toBe(false)
+  })
+
+  it('returns false, when origins do not match (V2)', () => {
+    const result = isSameOriginAsCurrentPage('http://www.google.com')
+    expect(result).toBe(false)
+  })
+
+  it('returns true, when relative url sent', () => {
+    const result = isSameOriginAsCurrentPage('/get-started')
+    expect(result).toBe(true)
   })
 })

--- a/src/urlUtilities.test.js
+++ b/src/urlUtilities.test.js
@@ -1,0 +1,31 @@
+import { parseUrl } from './urlUtilities'
+
+describe('parseUrl()', () => {
+  describe('parsing relative urls', () => {
+    const RELATIVE_URL = '/get-started'
+
+    it('returns pathname', () => {
+      const result = parseUrl(RELATIVE_URL)
+      expect(result.pathname).toBe('/get-started')
+    })
+
+    it('returns origin', () => {
+      const result = parseUrl(RELATIVE_URL)
+      expect(result.origin).toBe('http://localhost')
+    })
+  })
+
+  describe('parsing fully qualified urls', () => {
+    const FULL_URL = 'http://www.shave.com/get-started'
+
+    it('returns pathname', () => {
+      const result = parseUrl(FULL_URL)
+      expect(result.pathname).toBe('/get-started')
+    })
+
+    it('returns origin', () => {
+      const result = parseUrl(FULL_URL)
+      expect(result.origin).toBe('http://www.shave.com')
+    })
+  })
+})

--- a/src/urlUtilities.test.js
+++ b/src/urlUtilities.test.js
@@ -1,4 +1,8 @@
-import { parseUrl, isSameOriginAsCurrentPage } from './urlUtilities'
+import {
+  parseUrl,
+  isSameOriginAsCurrentPage,
+  removeOriginFromUrl,
+} from './urlUtilities'
 
 describe('parseUrl()', () => {
   describe('parsing relative urls', () => {
@@ -80,5 +84,57 @@ describe('isSameOriginAsCurrentPage()', () => {
   it('returns true, when relative url sent', () => {
     const result = isSameOriginAsCurrentPage('/get-started')
     expect(result).toBe(true)
+  })
+})
+
+describe('removeOriginFromUrl()', () => {
+  it('returns correctly, when no path is present', () => {
+    const mockInput = 'http://www.google.com'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/')
+  })
+
+  it('returns correctly, when path is forward slash', () => {
+    const mockInput = 'http://www.google.com/'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/')
+  })
+
+  it('returns correctly, when path is simple string', () => {
+    const mockInput = 'http://www.google.com/now'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/now')
+  })
+
+  it('returns correctly, when path is search param only', () => {
+    const mockInput = 'http://www.google.com?q=chicken'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/?q=chicken')
+  })
+
+  it('returns correctly, when path is hash', () => {
+    const mockInput = 'http://www.google.com#title'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/#title')
+  })
+
+  it('returns correctly, when path is complex', () => {
+    const mockInput = 'http://www.google.com/now?q=chicken#title'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/now?q=chicken#title')
+  })
+
+  it('returns correctly, when url contains no origin', () => {
+    const mockInput = '/shop/all-products'
+    const result = removeOriginFromUrl(mockInput)
+    expect(result).toBe('/shop/all-products')
+  })
+
+  it('throws, when url passed in is an object', () => {
+    const mockInput = { isObject: true }
+    const funcUnderTest = () => {
+      return removeOriginFromUrl(mockInput)
+    }
+    expect(funcUnderTest).toThrow()
   })
 })


### PR DESCRIPTION
## Proposed Changes
1) Introduce URL utility `isSameOriginAsCurrentPage()`
2) Introduce URL utility `removeOriginFromUrl()`
3) Ensure `MatchFactory` always identifies a non-match when the origins are different.  And ensure origin is not present when rendering `data-safelink-type="link"`

----

**Bug Revealed**
Avoids incorrect rendering of `data-safelink-type="link"` when it shouldn't be, but rather simple anchor.
See PHX-570.
See screenshot:

![CA_HelpCenter](https://user-images.githubusercontent.com/1548933/85474294-4d390f00-b569-11ea-813f-04960ea0b076.png)



