### PR TITLE
fix: retain state of 'to' parameter (FE-252)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/react-passage",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Link and Redirect to routes safely in your react applications",
   "author": "Jacob Kelley <jacob.kelley@dollarshaveclub.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "eslint-plugin-standard": "^4.0.1",
     "eslint-plugin-typescript-filenames": "^8.0.0",
     "gh-pages": "^2.0.1",
-    "history": "^4.10.1",
     "husky": "^4.2.3",
     "jest": "^24.9.0",
     "markdown-spellcheck": "^1.3.1",
@@ -119,5 +118,8 @@
     "dist",
     "src",
     "types"
-  ]
+  ],
+  "dependencies": {
+    "history": "^4.10.1"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
 import { matchPath, useLocation } from 'react-router'
 import PropTypes from 'prop-types'
 import { isSameOriginAsCurrentPage, removeOriginFromUrl } from './urlUtilities'
+import { toLocationObject } from './locationUtils'
 
 // Create our Context API
 const { Provider, Consumer } = createContext()
@@ -107,12 +108,13 @@ export const Link = forwardRef(
               </a>
             )
 
-          const pathname = removeOriginFromUrl(toStringFromLocationObject(to))
+          const toLocationObj = toLocationObject(to)
+          toLocationObj.pathname = removeOriginFromUrl(toLocationObj.pathname)
 
           return (
             <ReactRouterLink
               data-safelink-type="link"
-              to={pathname}
+              to={toLocationObj}
               {...remainingProps}
               ref={ref}
             >

--- a/src/locationUtils.js
+++ b/src/locationUtils.js
@@ -1,0 +1,27 @@
+import { createLocation } from 'history'
+
+// References:
+// https://github.com/ReactTraining/react-router/pull/5368/files#diff-066b73b6b32d50cbba621d56d70e3301R3-R10
+// https://github.com/ReactTraining/react-router/blob/ea44618e68f6a112e48404b2ea0da3e207daf4f0/packages/react-router-dom/modules/Link.js#L92-L95
+
+const resolveToLocation = (to, currentLocation) =>
+  typeof to === 'function' ? to(currentLocation) : to
+
+const normalizeToLocation = (to, currentLocation) => {
+  return typeof to === 'string'
+    ? createLocation(to, null, null, currentLocation)
+    : to
+}
+
+/**
+ * Converts any 'to' object (of type string, object or function) and outputs a
+ * location object, while retaining `search`, `hash` and `state`.
+ */
+export const toLocationObject = (to, currentLocation) => {
+  const locationObj = normalizeToLocation(
+    resolveToLocation(to, currentLocation),
+    currentLocation
+  )
+
+  return locationObj
+}

--- a/src/locationUtils.test.js
+++ b/src/locationUtils.test.js
@@ -1,0 +1,69 @@
+import { toLocationObject } from './locationUtils'
+
+// Reference: https://reactrouter.com/web/api/Link
+describe('toLocationObject()', () => {
+  const mockCurrentLocation = {
+    pathname: '/account',
+  }
+
+  it('converts from string', () => {
+    const mockTo = '/home'
+
+    const result = toLocationObject(mockTo, mockCurrentLocation)
+
+    expect(result.pathname).toEqual('/home')
+    expect(result.search).toEqual('')
+    expect(result.hash).toEqual('')
+    expect(result.state).toEqual(null)
+  })
+
+  it('converts from string (with query param and hash)', () => {
+    const mockTo = '/home?sort=name#555'
+
+    const result = toLocationObject(mockTo, mockCurrentLocation)
+
+    expect(result.pathname).toEqual('/home')
+    expect(result.search).toEqual('?sort=name')
+    expect(result.hash).toEqual('#555')
+    expect(result.state).toEqual(null)
+  })
+
+  it('converts from function', () => {
+    const mockTo = (location) => {
+      return {
+        pathname: '/join',
+        hash: '',
+        state: {
+          modal: true,
+          background: location,
+        },
+      }
+    }
+
+    const result = toLocationObject(mockTo, mockCurrentLocation)
+
+    expect(result.pathname).toEqual('/join')
+    expect(result.search).toEqual(undefined)
+    expect(result.hash).toEqual('')
+    expect(result.state).toEqual({
+      modal: true,
+      background: { pathname: '/account' },
+    })
+  })
+
+  it('converts from object', () => {
+    const mockTo = {
+      pathname: '/courses',
+      search: '?sort=name',
+      hash: '#the-hash',
+      state: { fromDashboard: true },
+    }
+
+    const result = toLocationObject(mockTo, mockCurrentLocation)
+
+    expect(result.pathname).toEqual('/courses')
+    expect(result.search).toEqual('?sort=name')
+    expect(result.hash).toEqual('#the-hash')
+    expect(result.state).toEqual({ fromDashboard: true })
+  })
+})

--- a/src/test.js
+++ b/src/test.js
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  Link as ReactRouterLink,
-  MemoryRouter,
-  Switch,
-  Route,
-} from 'react-router-dom'
+import { MemoryRouter, Switch, Route } from 'react-router-dom'
 import { useLocation } from 'react-router'
 import { Passage, Link, Redirect } from '.'
 import renderer from 'react-test-renderer'
@@ -26,7 +21,7 @@ describe('react-passage', () => {
     const component = renderer.create(<Link to={href}>Blades</Link>)
 
     it('renders an anchor tag', () => {
-      expectComponentToRenderSafeLink(component, 'a', href)
+      expectAnchorWith(component, href)
     })
 
     it('matches the snapshot', () => {
@@ -49,12 +44,12 @@ describe('react-passage', () => {
 
     it('renders an anchor tag, when path does not match', () => {
       const href = '/blades'
-      expectComponentToRenderSafeLink(renderDummyRouteTree(href), 'a', href)
+      expectAnchorWith(renderDummyRouteTree(href), href)
     })
 
     it('renders an anchor tag, when path the same, but origin is different', () => {
       const href = 'https://www.google.com/get-started'
-      expectComponentToRenderSafeLink(renderDummyRouteTree(href), 'a', href)
+      expectAnchorWith(renderDummyRouteTree(href), href)
     })
 
     it('matches the snapshot', () => {
@@ -106,29 +101,33 @@ describe('react-passage', () => {
       )
 
     it('renders a Link tag, when relative path matches', () => {
-      expectComponentToRenderSafeLink(
+      expectLinkWith(
         renderDummyRoutes(<Link to={hrefRelativeMatch}>Shave Core</Link>),
-        ReactRouterLink,
-        hrefRelativeMatch
+        { pathname: hrefRelativeMatch, hash: '', search: '', state: null }
+      )
+
+      expectLinkWith(
+        renderDummyRoutes(<Link to={hrefRelativeMatch}>Shave Core</Link>),
+        { pathname: hrefRelativeMatch, hash: '', search: '', state: null }
       )
     })
 
     it('renders a Link tag, when fully qualified url matches', () => {
-      expectComponentToRenderSafeLink(
+      expectLinkWith(
         renderDummyRoutes(<Link to={hrefFullyQualifiedMatch}>Shave Core</Link>),
-        ReactRouterLink,
-        hrefRelativeMatch
+        { pathname: hrefRelativeMatch, hash: '', search: '', state: null }
       )
     })
 
     it('renders a Link tag with Query Parementers', () => {
       const hrefWithQueryParams = '/get-started?source=foo&medium=nav'
       const LinkComponent = <Link to={hrefWithQueryParams}>Shave Core</Link>
-      expectComponentToRenderSafeLink(
-        renderDummyRoutes(LinkComponent),
-        ReactRouterLink,
-        hrefWithQueryParams
-      )
+      expectLinkWith(renderDummyRoutes(LinkComponent), {
+        pathname: '/get-started',
+        hash: '',
+        search: '?source=foo&medium=nav',
+        state: null,
+      })
       expect(LinkComponent).toMatchSnapshot()
     })
 
@@ -164,13 +163,12 @@ describe('react-passage', () => {
     })
 
     it('matches but is overridden with external flag', () => {
-      expectComponentToRenderSafeLink(
+      expectAnchorWith(
         renderDummyRoutes(
           <Link external to={hrefRelativeMatch}>
             Shave Core
           </Link>
         ),
-        'a',
         hrefRelativeMatch
       )
     })
@@ -241,19 +239,17 @@ describe('react-passage', () => {
   })
 })
 
-/**
- * Asserts that the component contains a child link-like element of type componentType with the provided href as a prop.
- * @param {renderer.ReactTestRenderer} component
- * @param {string | React.ComponentClass<any, any> | React.FunctionComponent<any>} componentType
- * @param {string} href
- * @example const component = renderer.create(<Link to='/foo'>Blades</Link>)
- * expectComponentToRenderSafeLink(component, Link, '/foo') // passes
- * expectComponentToRenderSafeLink(component, 'a', '/foo') // does not pass
- */
-function expectComponentToRenderSafeLink(component, componentType, href) {
-  const safeLink = component.root.findByType(componentType)
-  expect(safeLink).toBeTruthy()
+// ---Helpers---
+function expectAnchorWith(componentTree, href) {
+  const foundAnchor = componentTree.root.findByProps({
+    'data-safelink-type': 'a',
+  })
+  expect(foundAnchor.props.href).toBe(href)
+}
 
-  const linkHref = safeLink.props.href || safeLink.props.to
-  expect(linkHref).toBe(href)
+function expectLinkWith(componentTree, toLocationObject) {
+  const foundLink = componentTree.root.findByProps({
+    'data-safelink-type': 'link',
+  })
+  expect(foundLink.props.to).toEqual(toLocationObject)
 }


### PR DESCRIPTION
## Fixes

 - Fixes #27 
 - Fixes `to` as object and `to` as function to preserve `state` properly.  Useful when Passage matches an href and chooses to render as React Router Link (see DSC FE-252) (see https://reactrouter.com/web/api/Link/to-object).

## Proposed Changes

- Change

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
